### PR TITLE
feat: add array support for query value (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ pathcat("/users/:user_id/posts/:post_id", {
 	cool_flag: true,
 });
 // => '/users/123/posts/456?cool_flag=true'
+
+// You can also use arrays for query string values
+pathcat("/users/:user_id/posts/:post_id", {
+	user_id: "123",
+	post_id: 456,
+	cool_flag: true,
+	fields: ["title", "body"],
+});
+// => '/users/123/posts/456?cool_flag=true&fields=title&fields=body'
 ```
 
 ## Benchmark:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 /**
- * Represents a parameter value that can be used in a URL query or path.
+ * Represents a parameter value that can be used in a URL path.
  */
 export type ParamValue = string | number | boolean | null | undefined;
+
+/**
+ * Represents a parameter value that can be used in a URL query.
+ * This can be either a single value or an array of values.
+ */
+export type QueryValue = ParamValue | ParamValue[];
 
 /**
  * Drops the protocol from the start of a url string
@@ -28,7 +34,7 @@ export type ExtractRouteParams<T extends string> = string extends T
  * If the template has URL params (like `/users/:user_id/posts`), the query object must contain at least the user_id param
  */
 export type Query<Template extends string> = Record<ExtractRouteParams<Template>, ParamValue> &
-	Record<string, ParamValue>;
+	Record<string, QueryValue>;
 
 /**
  * Joins two paths together, removing any duplicate slashes between them.
@@ -113,7 +119,15 @@ function pathcatInternal(template: string, params: Query<string>) {
 	const queryParams = new URLSearchParams();
 	for (const [key, value] of Object.entries(params)) {
 		if (!usedKeys.has(key) && value !== undefined) {
-			queryParams.set(key, value as string);
+			if (Array.isArray(value)) {
+				for (const item of value) {
+					if (item !== undefined && item !== null) {
+						queryParams.append(key, String(item));
+					}
+				}
+			} else {
+				queryParams.set(key, String(value));
+			}
 		}
 	}
 

--- a/test.ts
+++ b/test.ts
@@ -50,6 +50,16 @@ describe("pathcat()", () => {
 		);
 
 		assert.equal(
+			pathcat("/users/:user/posts/:post", {
+				user: "1",
+				post: "2",
+				field: ["name", "age"],
+				param: true,
+			}),
+			"/users/1/posts/2?field=name&field=age&param=true"
+		);
+
+		assert.equal(
 			pathcat("https://example.com", "/users/:user_id/posts", {
 				user_id: "1234",
 				limit: 20,


### PR DESCRIPTION
**What did I change?**
I've separated ParamValue and QueryValue, which can be an array.

We can now do:
```ts
pathcat("https://example.com", "/:id", {
	id: "123",
	foo: ["b", "a", "r"],
});
// => 'https://example.com/123?foo=b&foo=a&foo=r'
```

And typescript will throw an error if used this way:
```ts
pathcat("https://example.com", "/:id", {
	id: ["1", "2", "3"], // cannot be an array
	foo: ["b", "a", "r"], // can be an array
});
```

**Why did I change it?**
This package is great, but it's true that query params can be arrays, and it can be interesting in some cases to be able to benefit from these advantages.